### PR TITLE
feat: split LogFunctions for processings and test-utils

### DIFF
--- a/src/processings/tests-utils-types.ts
+++ b/src/processings/tests-utils-types.ts
@@ -8,6 +8,22 @@ export interface ProcessingTestConfig {
   account: Account
 };
 
-export interface ProcessingTestContext extends ProcessingContext {
+export interface ProcessingTestContext extends Omit<ProcessingContext, 'log'> {
   cleanup: () => Promise<void>
+  log: LogTestFunctions
+}
+
+/**
+ * Log functions of tests
+ */
+export interface LogTestFunctions {
+  step: (msg: string) => void
+  error: (msg: string, extra: any) => void
+  warning: (msg: string, extra: any) => void
+  info: (msg: string, extra: any) => void
+  debug: (msg: string, extra: any) => void
+  task: (name: string) => void
+  progress: (taskName: string, progress: number, total: number) => void
+  testInfo: (msg: any, extra: any) => void
+  testDebug: (msg: any, extra: any) => void
 }

--- a/src/processings/tests-utils.js
+++ b/src/processings/tests-utils.js
@@ -33,9 +33,9 @@ const denseInspect = (arg) => {
 
 /**
  * Create log functions.
- * @param {boolean} [debug] - Enable debug logging.
- * @param {boolean} [testDebug] - Enable test debug logging.
- * @returns {import('./types.js').LogFunctions} Log functions.
+ * @param {boolean} debug - Enable debug logging.
+ * @param {boolean} testDebug - Enable test debug logging.
+ * @returns {import('./tests-utils-types.js').LogTestFunctions} Log functions.
  */
 const prepareLog = (debug, testDebug) => {
   return {
@@ -97,7 +97,7 @@ const axiosInstance = (config) => {
 /**
  * Create a WebSocket instance.
  * @param {import('./tests-utils-types.ts').ProcessingTestConfig} config - Configuration.
- * @param {import('./types.js').LogFunctions} log - Log functions.
+ * @param {import('./tests-utils-types.js').LogTestFunctions} log Log functions.
  * @returns {DataFairWsClient} WebSocket instance.
  */
 const wsInstance = (config, log) => {
@@ -114,8 +114,8 @@ const wsInstance = (config, log) => {
  * Create a context instance.
  * @param {any} initialContext - Initial context.
  * @param {import('./tests-utils-types.ts').ProcessingTestConfig} config - Configuration.
- * @param {boolean} [debug] - Enable debug logging.
- * @param {boolean} [testDebug] - Enable test debug logging.
+ * @param {boolean} debug - Enable debug logging.
+ * @param {boolean} testDebug - Enable test debug logging.
  * @returns {import('./tests-utils-types.js').ProcessingTestContext} Context instance.
  */
 export const context = (initialContext, config, debug, testDebug) => {

--- a/src/processings/types.ts
+++ b/src/processings/types.ts
@@ -21,13 +21,11 @@ export interface ProcessingContext {
  * Log functions.
  */
 export interface LogFunctions {
-  step: (msg: string) => void
-  error: (msg: string, extra: any) => void
-  warning: (msg: string, extra: any) => void
-  info: (msg: string, extra: any) => void
-  debug: (msg: string, extra: any) => void
-  task: (name: string) => void
-  progress: (taskName: string, progress: number, total: number) => void
-  testInfo: (msg: any, extra: any) => void
-  testDebug: (msg: any, extra: any) => void
+  step: (msg: string) => Promise<void>
+  error: (msg: string, extra?: any) => Promise<void>
+  warning: (msg: string, extra?: any) => Promise<void>
+  info: (msg: string, extra?: any) => Promise<void>
+  debug: (msg: string, extra?: any) => Promise<void>
+  task: (name: string) => Promise<void>
+  progress: (taskName: string, progress: number, total: number) => Promise<void>
 }


### PR DESCRIPTION
I updated the type of LogFunctions and introduced the LogTestFunctions type. LogFunctions is an object of asynchronous functions that return Promise<void> in @data-fair/processings, while LogTestFunctions contains non-asynchronous functions for the test-utils script.