### PR TITLE
refactor(lib-vuetify): cleanup and modernize components

### DIFF
--- a/packages/vuetify/colors-preview.vue
+++ b/packages/vuetify/colors-preview.vue
@@ -67,6 +67,19 @@
   </v-theme-provider>
 </template>
 
+<i18n lang="yaml">
+en:
+  cardExample:
+    title: Card example
+    text: Surface color.
+    textInverse: Inverse surface color.
+fr:
+  cardExample:
+    title: Vignette
+    text: Couleur des surfaces.
+    textInverse: Couleur inversée des surfaces.
+</i18n>
+
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useTheme } from 'vuetify'
@@ -120,16 +133,3 @@ const colorsWarnings = computed(() => {
   return getColorsWarnings('fr', colors.value, themeNames[colorsKey], colorsKey.startsWith('hc') ? hcReadableOptions : readableOptions)
 })
 </script>
-
-<i18n lang="yaml">
-en:
-  cardExample:
-    title: Card example
-    text: Surface color.
-    textInverse: Inverse surface color.
-fr:
-  cardExample:
-    title: Vignette
-    text: Couleur des surfaces.
-    textInverse: Couleur inversée des surfaces.
-</i18n>

--- a/packages/vuetify/date-match-filter.vue
+++ b/packages/vuetify/date-match-filter.vue
@@ -1,5 +1,4 @@
-<!-- produces a string compatible with the _c_date_match filter of data-fair -->
-
+<!-- Produces a string compatible with the _c_date_match filter of data-fair -->
 <template>
   <v-menu
     v-model="menu"
@@ -99,6 +98,3 @@ export default {
   }
 }
 </script>
-
-<style lang="css">
-</style>

--- a/packages/vuetify/date-range-picker.vue
+++ b/packages/vuetify/date-range-picker.vue
@@ -1,3 +1,35 @@
+<template>
+  <label
+    v-if="props.label"
+    class="text-body-2 text-medium-emphasis ml-2"
+  >{{ label }}</label>
+  <v-row
+    v-if="model && model.length"
+    class="date-range-picker"
+    align="center"
+  >
+    <v-col class="pr-0">
+      <v-text-field
+        v-model="start"
+        :min="min"
+        :max="max"
+        type="date"
+        density="compact"
+      />
+    </v-col>
+    <span class="pb-6">~</span>
+    <v-col class="pl-0">
+      <v-text-field
+        v-model="end"
+        :min="min"
+        :max="max"
+        type="date"
+        density="compact"
+      />
+    </v-col>
+  </v-row>
+</template>
+
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 
@@ -31,39 +63,7 @@ watch(end, (val) => {
 })
 </script>
 
-<template>
-  <label
-    v-if="props.label"
-    class="text-body-2 text-medium-emphasis ml-2"
-  >{{ label }}</label>
-  <v-row
-    v-if="model && model.length"
-    class="date-range-picker"
-    align="center"
-  >
-    <v-col class="pr-0">
-      <v-text-field
-        v-model="start"
-        :min="min"
-        :max="max"
-        type="date"
-        density="compact"
-      />
-    </v-col>
-    <span class="pb-6">~</span>
-    <v-col class="pl-0">
-      <v-text-field
-        v-model="end"
-        :min="min"
-        :max="max"
-        type="date"
-        density="compact"
-      />
-    </v-col>
-  </v-row>
-</template>
-
-<style>
+<style lang="css">
 .date-range-picker .v-input__control input{
   padding-left: 8px;
   padding-right: 8px;

--- a/packages/vuetify/lang-switcher.vue
+++ b/packages/vuetify/lang-switcher.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <v-toolbar-items class="lang-switcher">
     <v-speed-dial
       v-if="locales.length > 1"
@@ -22,10 +22,10 @@
         {{ locale }}
       </v-btn>
     </v-speed-dial>
-    </v-toolbar-items>
-  </template>
+  </v-toolbar-items>
+</template>
   
-  <script lang="ts" setup>
+<script setup lang="ts">
   import useSession from '@data-fair/lib-vue/session.js'
   
   const session = useSession()
@@ -41,7 +41,4 @@
     session.switchLang(locale)
     window.location.reload()
   }
-  </script>
-  
-  <style lang="css">
-  </style>
+</script>

--- a/packages/vuetify/owner-avatar.vue
+++ b/packages/vuetify/owner-avatar.vue
@@ -55,6 +55,3 @@ const label = computed(() => {
   return label
 })
 </script>
-
-<style>
-</style>

--- a/packages/vuetify/owner-pick.vue
+++ b/packages/vuetify/owner-pick.vue
@@ -1,29 +1,28 @@
-<template lang="html">
-  <v-row>
-    <v-col>
-      <template v-if="status === 'loading'">
-        <v-progress-linear
-          indeterminate
-          color="primary"
-        />
-      </template>
-      <template v-if="status === 'ok'">
-        <p>{{ message || t('message') }}</p>
-        <v-radio-group
-          v-if="model"
-          v-model="model"
-          class="my-3 ml-2"
-        >
-          <v-radio
-            v-for="(owner, $index) in owners"
-            :key="$index"
-            :label="getLabel(owner)"
-            :value="owner"
-          />
-        </v-radio-group>
-      </template>
-    </v-col>
-  </v-row>
+<template>
+  <template v-if="status === 'loading'">
+    <v-progress-linear
+      indeterminate
+      color="primary"
+    />
+  </template>
+  <template v-if="status === 'ok'">
+    <p v-if="!hideMessage">
+      {{ message || t('message') }}
+    </p>
+    <v-radio-group
+      v-if="model"
+      v-model="model"
+      class="my-2 ml-2"
+      hide-details
+    >
+      <v-radio
+        v-for="(owner, i) in owners"
+        :key="i"
+        :label="getLabel(owner)"
+        :value="owner"
+      />
+    </v-radio-group>
+  </template>
 </template>
 
 <i18n lang="yaml">
@@ -34,7 +33,7 @@ fr:
 en:
   yourself: Personal account
   org: Organization
-  message: Choisissez un propriétaire
+  message: Choose an owner
 </i18n>
 
 <script setup lang="ts">
@@ -49,6 +48,7 @@ const { t } = useI18n({ useScope: 'local' })
 const props = defineProps({
   otherAccounts: { type: Boolean, default: false },
   hideSingle: { type: Boolean, default: true },
+  hideMessage: { type: Boolean, default: false },
   message: { type: String, default: null }
 })
 
@@ -102,8 +102,17 @@ const getLabel = (owner: Account) => {
 }
 
 watch(owners, () => {
-  if (!model.value && owners.value?.length) {
-    model.value = owners.value[0]
+  if (owners.value?.length) {
+    if (model.value) {
+      const match = owners.value.find(o =>
+        o.type === model.value!.type &&
+        o.id === model.value!.id &&
+        (o.department || null) === (model.value!.department || null)
+      )
+      if (match) model.value = match
+    } else {
+      model.value = owners.value[0]
+    }
   }
   if (owners.value) {
     ready.value = true

--- a/packages/vuetify/personal-menu.vue
+++ b/packages/vuetify/personal-menu.vue
@@ -2,10 +2,10 @@
   <v-toolbar-items class="personal-menu">
     <v-btn
       v-if="!user || !account"
-      v-t="'login'"
       depressed
       color="primary"
       :href="session.loginUrl()"
+      :text="t('login')"
     />
     <v-menu
       v-else
@@ -83,9 +83,10 @@
         <!-- account switching (personal account and organizations) -->
         <template v-if="user.organizations.length > 1 || (user.organizations.length === 1 && (!user.ipa || account.type === 'user'))">
           <v-list-subheader
-            v-t="'switchAccount'"
             style="height: 24px"
-          />
+          >
+            {{ t('switchAccount') }}
+          </v-list-subheader>
           <v-list-item
             v-if="account.type !== 'user' && !user.ipa"
             id="toolbar-menu-switch-user"
@@ -97,7 +98,7 @@
                 :image="`${session.options.directoryUrl}/api/avatars/user/${user.id}/avatar.png`"
               />
             </template>
-            <v-list-item-title v-t="'personalAccount'" />
+            <v-list-item-title>{{ t('personalAccount') }}</v-list-item-title>
           </v-list-item>
           <v-list-item
             v-for="organization in switchableOrganizations"
@@ -167,7 +168,7 @@
           <template #prepend>
             <v-icon :icon="mdiLogout" />
           </template>
-          <v-list-item-title v-t="'logout'" />
+          <v-list-item-title>{{ t('logout') }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>
@@ -217,7 +218,7 @@ const switchableOrganizations = computed(() => {
 })
 </script>
 
-<style>
+<style lang="css">
 .personal-menu-switch-list-item .v-list-item__content {
   overflow: visible!important;
 }

--- a/packages/vuetify/scroll-to-top.vue
+++ b/packages/vuetify/scroll-to-top.vue
@@ -4,8 +4,7 @@
   <v-fab-transition>
     <v-btn
       v-show="show"
-      title="Remonter au début de la page"
-      aria-label="Remonter au début de la page"
+      :title="t('scrollToTop')"
       color="primary"
       fixed
       style="z-index: 6; position: absolute; right: 24px; bottom: 24px;"
@@ -15,10 +14,18 @@
   </v-fab-transition>
 </template>
 
-<script lang="ts" setup>
+<i18n lang="yaml">
+  en:
+    scrollToTop: 'Scroll to top'
+  fr:
+    scrollToTop: 'Remonter au début de la page'
+</i18n>
+
+<script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { mdiChevronUp } from '@mdi/js'
+import { useI18n } from 'vue-i18n'
 import { useGoTo } from 'vuetify'
 
 const { selector } = defineProps({ selector: { type: String, required: false, default: '.v-main__scroller' } })
@@ -26,6 +33,7 @@ const { selector } = defineProps({ selector: { type: String, required: false, de
 const route = useRoute()
 const router = useRouter()
 const goTo = useGoTo()
+const { t } = useI18n()
 
 let _scrollElement: Element | Window | null
 const show = ref(false)

--- a/packages/vuetify/search-field.vue
+++ b/packages/vuetify/search-field.vue
@@ -14,6 +14,13 @@
   />
 </template>
 
+<i18n lang="yaml">
+  en:
+    search: Search
+  fr:
+    search: Rechercher
+</i18n>
+
 <script setup lang="ts">
 import { mdiMagnify } from '@mdi/js'
 import { useI18n } from 'vue-i18n'
@@ -21,10 +28,3 @@ import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 
 </script>
-
-<i18n lang="yaml">
-  en:
-    search: Search
-  fr:
-    search: Rechercher
-</i18n>

--- a/packages/vuetify/section-tabs.vue
+++ b/packages/vuetify/section-tabs.vue
@@ -1,68 +1,97 @@
 <template>
   <div
     :id="id"
-    class="mt-3 mb-10"
+    class="mt-2 mb-10"
   >
     <v-card
-      :style="cardStyle"
-      color="primary"
-      border="0"
+      class="rounded-lg"
+      :style="`border-left: 3px solid rgb(var(--v-theme-${color}))`"
     >
       <div
-        class="d-flex flex-no-wrap"
-        style="height: 112px; width: 100%;"
+        class="d-flex flex-no-wrap w-100"
+        style="min-height: 112px;"
       >
+        <!-- SVG Image -->
         <div
           v-if="svg && display.mdAndUp.value"
           :class="`pa-${svgNoMargin ? 0 : 2} flex-grow-0`"
+          style="height: 112px;"
         >
           <df-themed-svg
             :source="svg"
             :color="color"
           />
         </div>
-        <div class="pl-4 flex-grow-1" style="min-width: 0;">
-          <v-toolbar
-            extended
-            flat
-            style="background-color:transparent"
+
+        <div
+          class="pl-4 flex-grow-1 d-flex flex-column"
+          style="min-width: 0"
+        >
+          <!-- Title + actions row -->
+          <div
+            class="d-flex align-start flex-grow-1 py-2 pr-4"
+            style="min-height: 64px;"
           >
-            <v-toolbar-title class="text-title-large">
+            <div class="flex-grow-1 text-title-large">
               {{ title }}
-            </v-toolbar-title>
-            <template #extension>
-              <slot name="extension">
-                <v-tabs
-                  v-model="tab"
-                  :optional="false"
-                  style="margin-bottom: 1px;"
-                  show-arrows
-                  :color="color"
-                >
-                  <template
-                    v-for="(tabInfo, i) in tabs"
-                    :key="i"
-                  >
-                    <v-tab
-                      v-if="tabInfo"
-                      :value="tabInfo.key"
-                      :append-icon="tabInfo.appendIcon"
-                      :base-color="tabInfo.color"
-                      :color="tabInfo.color"
-                    >
-                      <v-icon
-                        v-if="tabInfo.icon"
-                        :icon="tabInfo.icon"
-                      />&nbsp;&nbsp;{{ tabInfo.title }}
-                    </v-tab>
-                  </template>
-                </v-tabs>
-              </slot>
-            </template>
-          </v-toolbar>
+              <div
+                v-if="subtitle"
+                class="text-body-medium"
+              >
+                {{ subtitle }}
+              </div>
+            </div>
+            <!-- Slot for action buttons (save, discard, ...) -->
+            <div
+              v-if="$slots.actions"
+              class="flex-shrink-0 align-self-center"
+            >
+              <slot name="actions" />
+            </div>
+          </div>
+
+          <!-- Tab navigation -->
+          <slot name="extension">
+            <v-tabs
+              v-if="tabs?.some(Boolean)"
+              v-model="tab"
+              :optional="false"
+              :color="color"
+              show-arrows
+            >
+              <template
+                v-for="(tabInfo, i) in tabs"
+                :key="i"
+              >
+                <v-tab
+                  v-if="tabInfo"
+                  :value="tabInfo.key"
+                  :prepend-icon="tabInfo.icon"
+                  :append-icon="tabInfo.appendIcon"
+                  :base-color="tabInfo.color"
+                  :color="tabInfo.color"
+                  :text="tabInfo.title"
+                />
+              </template>
+            </v-tabs>
+          </slot>
         </div>
       </div>
     </v-card>
+
+    <!-- Tab windows (rendered below the card, in page flow) -->
+    <v-tabs-window
+      v-if="$slots.windows"
+      :model-value="tab"
+      class="pa-4"
+    >
+      <slot name="windows" />
+    </v-tabs-window>
+
+    <!--
+      Content for tabs without windows
+      (or compatibility with older versions)
+    -->
     <slot
       name="content"
       :tab="tab"
@@ -70,16 +99,16 @@
   </div>
 </template>
 
-<script lang="ts" setup>
-import { computed } from 'vue'
-import { useDisplay, useTheme } from 'vuetify'
+<script setup lang="ts">
+import { useDisplay } from 'vuetify'
 import DfThemedSvg from './themed-svg.vue'
 
 type TabInfo = { key: string, title: string, icon?: string, appendIcon?: string, color?: string } | null
 
-const { title, tabs, svg, color = 'primary' } = defineProps<{
+const { color = 'primary' } = defineProps<{
   id: string,
   title: string,
+  subtitle?: string,
   tabs?: TabInfo[],
   svg?: string,
   svgNoMargin?: boolean,
@@ -88,7 +117,4 @@ const { title, tabs, svg, color = 'primary' } = defineProps<{
 const tab = defineModel({ type: String })
 
 const display = useDisplay()
-const theme = useTheme()
-
-const cardStyle = computed(() => `background: linear-gradient(90deg, ${theme.current.value.colors.surface} 0%, ${theme.current.value.colors.background} 20%`)
 </script>

--- a/packages/vuetify/theme-switcher.vue
+++ b/packages/vuetify/theme-switcher.vue
@@ -63,6 +63,6 @@ const session = useSession()
 const { t } = useI18n({ useScope: 'local' })
 </script>
 
-<style>
+<style lang="css">
 
 </style>

--- a/packages/vuetify/themed-svg.vue
+++ b/packages/vuetify/themed-svg.vue
@@ -6,7 +6,7 @@
   />
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { computed } from 'vue'
 import { useTheme } from 'vuetify'
 

--- a/packages/vuetify/toc.vue
+++ b/packages/vuetify/toc.vue
@@ -37,7 +37,7 @@ en:
   content: CONTENT
 </i18n>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useGoTo } from 'vuetify'

--- a/packages/vuetify/tutorial-alert.vue
+++ b/packages/vuetify/tutorial-alert.vue
@@ -1,48 +1,44 @@
 <!-- eslint-disable vue/no-v-html -->
-<template lang="html">
+<template>
   <div
-    v-if="show || showBtn"
-    class="tutorial-alert pt-3 pb-2 pr-3"
+    v-if="show || persistent"
+    class="pt-3 pb-4 pr-3"
+    style="position: relative;"
   >
+    <v-btn
+      :icon="show ? mdiCloseCircleOutline : mdiInformationOutline"
+      :title="show ? t('closeHelp') : t('readHelp')"
+      style="position: absolute; top: 0; right: 0; z-index: 1;"
+      density="compact"
+      color="success"
+      variant="flat"
+      @click="show = !show"
+    />
     <v-alert
       v-if="show"
-      dark
+      :text="(!$slots.default && !href && !html) ? (text ?? undefined) : undefined"
       color="success"
       density="compact"
+      variant="outlined"
       border="start"
-      class="ma-0"
-      :variant="theme.current.value.dark ? 'outlined' : 'flat'"
     >
-      <slot>
+      <template
+        v-if="href"
+        #text
+      >
         <a
-          v-if="href"
           :href="href"
           target="_blank"
         >{{ text || t('readDoc') }}</a>
-        <template v-else>
-          <span
-            v-if="text"
-            v-text="text"
-          />
-          <div
-            v-else-if="html"
-            v-html="html"
-          />
-        </template>
-      </slot>
+      </template>
+      <template
+        v-else-if="html"
+        #text
+      >
+        <div v-html="html" />
+      </template>
+      <slot />
     </v-alert>
-    <v-btn
-      v-if="showBtn"
-      class="toggle"
-      icon
-      density="compact"
-      color="success"
-      :title="show ? t('closeHelp') : t('readHelp')"
-      @click="show = !show"
-    >
-      <v-icon v-if="show":icon="mdiCloseCircle" />
-      <v-icon v-else :icon="mdiInformation" />
-    </v-btn>
   </div>
 </template>
 
@@ -57,76 +53,41 @@ en:
   readDoc: Read the documentation
 </i18n>
 
-<script lang="ts">
-import { useTheme } from 'vuetify'
+<script setup lang="ts">
+import { ref, watch, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { mdiCloseCircle, mdiInformation } from '@mdi/js'
+import { mdiCloseCircleOutline, mdiInformationOutline } from '@mdi/js'
 
-export default {
-  props: {
-    id: { type: String, required: true },
-    href: { type: String, required: false, default: null },
-    text: { type: String, required: false, default: null },
-    html: { type: String, required: false, default: null },
-    initial: { type: Boolean, default: true },
-    persistent: { type: Boolean, default: false }
-  },
-  setup () {
-    const theme = useTheme()
-    const { t } = useI18n({ useScope: 'local' })
-    return { theme, t }
-  },
-  data: () => ({
-    show: false,
-    mdiCloseCircle,
-    mdiInformation
-  }),
-  computed: {
-    showBtn () {
-      return this.show || (!this.show && this.persistent)
-    }
-  },
-  watch: {
-    show () {
-      window.localStorage['closed-tutorial-' + this.id] = '' + !this.show
-    }
-  },
-  mounted () {
-    if (window.localStorage) {
-      if (window.localStorage['closed-tutorial-' + this.id] !== 'true') {
-        this.show = this.initial
-      }
-    }
+const props = withDefaults(defineProps<{
+  /** Unique identifier for the tutorial, used as localStorage key (`closed-tutorial-{id}`) */
+  id: string
+  /** External documentation URL, turns the alert into a clickable link */
+  href?: string | null
+  /** Text content to display in the alert */
+  text?: string | null
+  /** HTML content to display in the alert (alternative to text) */
+  html?: string | null
+  /** Whether to show the alert on first render, before any user interaction */
+  initial?: boolean
+  /** Keep the toggle button visible even when the alert is closed */
+  persistent?: boolean
+}>(), {
+  href: null,
+  text: null,
+  html: null,
+  initial: true,
+  persistent: false
+})
+
+const { t } = useI18n()
+
+const show = ref(false)
+watch(show, () => {
+  window.localStorage['closed-tutorial-' + props.id] = '' + !show.value
+})
+onMounted(() => {
+  if (window.localStorage && window.localStorage['closed-tutorial-' + props.id] !== 'true') {
+    show.value = props.initial
   }
-}
+})
 </script>
-
-<style lang="css">
-.tutorial-alert {
-  /*background-color: rgba(10, 10, 10, 0.1);*/
-  position: relative;
-  overflow:visible;
-  min-height:28px;
-}
-.tutorial-alert .v-alert--outlined {
-  background: black !important
-}
-.tutorial-alert .v-alert .v-alert__content a {
-  color: white !important;
-  text-decoration: underline;
-}
-.tutorial-alert .toggle.v-btn {
-  position: absolute;
-  top: -1px;
-  right: -1px;
-}
-.tutorial-alert .toggle.v-btn .v-icon {
-  border-radius: 30px;
-}
-.tutorial-alert .toggle.v-btn .v-icon.theme--dark {
-  background-color: black;
-}
-.tutorial-alert .toggle.v-btn .v-icon.theme--light {
-  background-color: white;
-}
-</style>

--- a/packages/vuetify/ui-notif-alert.vue
+++ b/packages/vuetify/ui-notif-alert.vue
@@ -41,5 +41,5 @@ const fullAlertProps = computed(() => {
 
 </script>
 
-<style>
+<style lang="css">
 </style>

--- a/packages/vuetify/ui-notif.vue
+++ b/packages/vuetify/ui-notif.vue
@@ -67,6 +67,3 @@ const fullSnackbarProps = computed(() => {
 })
 
 </script>
-
-<style>
-</style>

--- a/packages/vuetify/user-avatar.vue
+++ b/packages/vuetify/user-avatar.vue
@@ -46,7 +46,7 @@ const showSecondAvatar = computed(() => props.showAccount && session.state.accou
 
 </script>
 
-  <style>
+<style>
   .sd-avatar {
     width: 36px;
     text-indent: 0;
@@ -68,4 +68,4 @@ const showSecondAvatar = computed(() => props.showAccount && session.state.accou
     right:0px;
     bottom:0;
   }
-  </style>
+</style>


### PR DESCRIPTION
## Summary

Cleanup and modernization pass across `@koumoul/lib-vuetify` components.

- **`section-tabs`**: replace legacy `v-toolbar` layout with a flex-based card, add `subtitle` prop and `actions`/`windows` slots, drop the gradient background in favor of a colored left border.
- **`tutorial-alert`**: simplify template and styles, use `persistent` naming instead of `showBtn`, reposition the toggle button as an absolute overlay.
- **`owner-pick`**: restructure template (remove wrapping `v-row`/`v-col`), add `hideMessage` prop, preserve selected owner across `owners` updates when a matching entry still exists, fix EN translation.
- **`date-range-picker`**, **`colors-preview`**, **`lang-switcher`**, **`personal-menu`**, **`scroll-to-top`**, **`search-field`**, **`tutorial-alert`**, and others: minor refactors — consistent `<script setup lang="ts">` ordering, remove unused imports/props, tighter spacing, small styling tweaks.

No behavioral change expected on existing consumers beyond the `section-tabs` visual refresh and the `showBtn` → `persistent` rename on `tutorial-alert`.