### PR TITLE
fix(lib-vuetify): assorted small fixes

### DIFF
--- a/packages/types-builder/build.ts
+++ b/packages/types-builder/build.ts
@@ -359,6 +359,7 @@ const emit = defineEmits(emits)
         for (const locale of vjsfLocales) {
           const schemaVjsfOpts = { ...schema['x-vjsf'] }
           delete schemaVjsfOpts.compName
+          console.log(`  compiledLayout ${locale} options: ${JSON.stringify(schemaVjsfOpts)}`)
           const otherSchemas = { ...schemas }
           for (const [key, otherSchema] of Object.entries(schemas)) {
             if (key === schema.$id) continue
@@ -375,7 +376,6 @@ const emit = defineEmits(emits)
             fullOptions.components[componentInfo.name] = componentInfo
           }
 
-          console.log(`  compiledLayout ${locale} options: ${JSON.stringify(schemaVjsfOpts)}`)
           const compiledLayout = compileLayout(schema, fullOptions)
           let compiledLayoutCode = await serializeCompiledLayout(compiledLayout)
           // The serialized code declares `const compiledLayout = {...}`.

--- a/packages/vuetify/layout-fetch-error.vue
+++ b/packages/vuetify/layout-fetch-error.vue
@@ -64,7 +64,7 @@ const { error, backTo = '/', backLabel } = defineProps<{
 }>()
 
 const { t } = useI18n({ useScope: 'local' })
-const { switchOrganization, user } = useSession()
+const { switchOrganization, user, account } = useSession()
 
 const statusCode = computed(() => error?.statusCode ?? error?.status ?? 500)
 
@@ -99,9 +99,25 @@ const switchOrg = computed(() => {
   try { owner = JSON.parse(rawOwner) } catch { return null }
   if (!owner || owner.type !== 'organization' || !owner.id) return null
 
-  return user.value.organizations?.find(o =>
-    o.id === owner!.id && (o.department ?? undefined) === (owner!.department ?? undefined)
-  ) ?? null
+  const orgs = user.value.organizations ?? []
+  const ownerDept = owner.department ?? undefined
+  const isCurrentAccount = (o: { id: string, department?: string }) =>
+    account.value?.type === 'organization' &&
+    account.value.id === o.id &&
+    (account.value.department ?? undefined) === (o.department ?? undefined)
+
+  // Prefer a membership matching the resource's department exactly...
+  const exact = orgs.find(o =>
+    o.id === owner!.id && (o.department ?? undefined) === ownerDept && !isCurrentAccount(o)
+  )
+  if (exact) return exact
+  // ...otherwise fall back to a membership at the organization root: in
+  // simple-directory's authz model, root access generally grants visibility
+  // over department-scoped resources.
+  if (ownerDept) {
+    return orgs.find(o => o.id === owner!.id && !o.department && !isCurrentAccount(o)) ?? null
+  }
+  return null
 })
 
 const doSwitch = () => {

--- a/packages/vuetify/personal-menu.vue
+++ b/packages/vuetify/personal-menu.vue
@@ -182,9 +182,8 @@ fr:
   openPersonalMenu: Ouvrez le menu personnel
   personalAccount: Compte personnel
   switchAccount: Changer de compte
-  adminMode: mode admin
+  adminMode: Mode admin
   backToAdmin: Revenir à ma session administrateur
-  darkMode: mode nuit
   plannedDeletion: La suppression de l'utilisateur {name} et toutes ses informations est programmée le {plannedDeletion}.
   cancelDeletion: Annuler la suppression de l'utilisateur
 en:
@@ -193,9 +192,8 @@ en:
   openPersonalMenu: Open personal menu
   personalAccount: Personal account
   switchAccount: Switch account
-  adminMode: admin mode
+  adminMode: Admin mode
   backToAdmin: Return to administrator session
-  darkMode: night mode
   plannedDeletion: The deletion of the user {name} and all its data is planned on the {plannedDeletion}.
   cancelDeletion: Cancel the deletion of the user
 </i18n>


### PR DESCRIPTION
## Summary

A batch of unrelated small fixes.

- **`fix(lib-vuetify)`: root-of-org switch fallback in `layout-fetch-error`** — the 403 "switch account" affordance only matched user memberships when their department exactly equalled the resource's `x-owner.department`. A user with access only at the root of the organization was never offered a switch, even though root access generally grants visibility over department-scoped resources. The matcher now prefers an exact-department membership and falls back to a root membership of the same org; the current account is excluded from candidates to avoid no-op switches.
- **`fix(lib-vuetify)`: capitalize `Admin mode` i18n label in `personal-menu`** — the "Admin mode" toggle (fr/en) now starts with a capital letter. The dead `darkMode` key (never referenced via `t()`) is dropped from `personal-menu`.
- **`fix(types-builder)`: log `compiledLayout` options before attaching schemas** — the `compiledLayout {locale} options: ...` log was huge because it ran after `schemaVjsfOpts.ajvOptions = { schemas: otherSchemas }`, which serialized the entire schema collection. The log is now emitted right after `delete schemaVjsfOpts.compName`, matching the pattern already used in the `vjsf` section above it.