### PR TITLE
fix(lib-node): destroy streamed error response body to avoid socket leak

### DIFF
--- a/packages/node/axios.ts
+++ b/packages/node/axios.ts
@@ -46,7 +46,8 @@ export function axiosBuilder (opts: CreateAxiosDefaults = {}, beforeInterceptors
     delete error.response.request
     error.response.config = { method: error.response.config.method, url: error.response.config.url, data: error.response.config.data }
     if (error.response.config.data && error.response.config.data._writableState) delete error.response.config.data
-    if (error.response.data && error.response.data._readableState) delete error.response.data
+    // destroy() a streamed error body before dropping it, else its socket leaks
+    if (error.response.data && error.response.data._readableState) { error.response.data.destroy(); delete error.response.data }
     let messageText = error.response.statusText
     if (error.response.data) {
       messageText = typeof error.response.data === 'string' ? error.response.data : JSON.stringify(error.response.data)


### PR DESCRIPTION
A response requested with `responseType: 'stream'` whose status fails the request's `validateStatus` rejects with the body still an unconsumed `Readable` bound to its keepalive socket. The error interceptor dropped that reference (`delete error.response.data`) without draining it, so the socket was never released. After `maxSockets` (8) such errors against a host, its agentkeepalive pool is exhausted and **every subsequent request to that host hangs forever** (the wait for a free socket isn't covered by the axios `timeout`).

Fix: `destroy()` the stream before deleting the reference.

**Why now:** surfaced in `@data-fair/processings` v6, the first consumer to stream tarball downloads from the registry — its 403/404 plugin-download paths (permission / missing-plugin tests) leaked a socket each, eventually wedging all registry downloads until an API restart.

**Regression risks:**
- `destroy()` is guarded by `_readableState`, so it only runs on a Readable body; non-stream error bodies are untouched.
- The reference was already being deleted immediately after, so no consumer could read the body post-interceptor — `destroy()` only adds socket cleanup, no behavior change for callers.
