### PR TITLE
feat(lib-vue): emit native d-frame notifications instead of v-iframe format

### DIFF
--- a/packages/vue/ui-notif.ts
+++ b/packages/vue/ui-notif.ts
@@ -1,6 +1,6 @@
 // simple composable to display store a UI notification
-// this will be transmitted to frame parent if available (compatible with v-iframe uiNotification message type)
-// or can be displayed locally by @data-fair/lib-vuetify/ui-notif.vue
+// when embedded it is transmitted to the parent as a native d-frame notification message
+// (['df-child', 'notif', notif]), or it can be displayed locally by @data-fair/lib-vuetify/ui-notif.vue
 
 import type { App } from 'vue'
 import { shallowRef, inject } from 'vue'
@@ -66,13 +66,41 @@ export function getFullNotif (notif: PartialUiNotif, defaultType: UiNotifBase['t
   } as UiNotifBase
 }
 
+// native d-frame child -> parent notification payload, mirrors the `Notif`
+// type from @data-fair/frame (lib/messages.ts), kept inline to avoid a
+// dependency on @data-fair/frame from this foundational package
+export type DFrameNotif = {
+  type: 'default' | 'info' | 'success' | 'warning' | 'error'
+  title: string
+  detail?: string
+}
+
+// convert a resolved UiNotif into the native d-frame Notif shape; mirrors
+// @data-fair/frame's convertVIframeUiNotif so the host renders notifications
+// identically to the former v-iframe-compat path
+export function toDFrameNotif (notif: UiNotif): DFrameNotif {
+  if (notif.type === 'error') {
+    return {
+      type: notif.clientError ? 'warning' : 'error',
+      title: notif.msg,
+      detail: notif.errorMsg
+    }
+  }
+  return {
+    type: notif.type ?? 'default',
+    title: notif.msg
+  }
+}
+
 export const getUiNotif = () => {
   const notification = shallowRef(null as null | UiNotif)
   function sendUiNotif (partialNotif: PartialUiNotif) {
     const notif = notification.value = getFullNotif(partialNotif)
     if (inIframe) {
-      if (notif.type === 'error') delete notif.error
-      window.top?.postMessage({ vIframe: true, uiNotification: notif }, '*')
+      // emit the native d-frame notification message consumed by an embedding
+      // <d-frame> host; v-iframe is deprecated so the legacy
+      // { vIframe: true, uiNotification } payload is no longer emitted
+      window.parent.postMessage(['df-child', 'notif', toDFrameNotif(notif)], '*')
     } else {
       console.log('iframe notification', notif)
     }


### PR DESCRIPTION
## Summary

- `sendUiNotif` (`@data-fair/lib-vue/ui-notif`) now posts the native d-frame message `['df-child', 'notif', { type, title, detail }]` to `window.parent` instead of the deprecated v-iframe `{ vIframe: true, uiNotification }` payload to `window.top`.
- New `toDFrameNotif` converter mirrors `@data-fair/frame`'s `convertVIframeUiNotif`, so embedding hosts render notifications identically: client errors → `warning`, server errors → `error`, `msg` → `title`, `errorMsg` → `detail`.
- Drops one conversion hop at the frame boundary now that v-iframe is deprecated and no longer needs to be emitted.
- No new dependency: the d-frame `Notif` shape is kept inline to avoid coupling this foundational package to `@data-fair/frame`. Host consumers (e.g. data-fair's `frame-notif.ts`) already consume the `{ type, title, detail }` shape, so no host-side change is required.