### PR TITLE
feat(vue): add useAutoScrollBottom stick-to-bottom composable

### DIFF
--- a/packages/vue/auto-scroll-bottom.ts
+++ b/packages/vue/auto-scroll-bottom.ts
@@ -1,0 +1,55 @@
+import { ref, watch, toValue, type MaybeRefOrGetter } from 'vue'
+import { useScroll, useEventListener } from '@vueuse/core'
+
+/**
+ * Stick-to-bottom autoscroll for a growing, live region (a run log, a chat
+ * transcript, ...): follows new content while the user is at the bottom, any
+ * upward scroll or wheel-up stops it, scrolling back to the bottom resumes.
+ *
+ * `target` is what actually scrolls — pass `window` (or the current document's
+ * scroller) for a page that scrolls as a whole, or a getter returning the inner
+ * scrollable element when the growing region lives inside an `overflow: auto`
+ * container. VueUse's `arrivedState.bottom` carries a built-in 1px tolerance,
+ * and appending content fires no scroll event, so following only ever turns off
+ * on a real upward scroll — no manual threshold needed.
+ *
+ * @param target the scroll container: `window`, an element, or a ref/getter to
+ *   one (tolerates `null`/`undefined` while the element is not yet mounted)
+ * @param growthSignal reactive getter for the content length (the growth signal)
+ * @param isActive getter telling whether the source is still streaming/growing
+ */
+export const useAutoScrollBottom = (
+  target: MaybeRefOrGetter<HTMLElement | Window | null | undefined>,
+  growthSignal: () => number,
+  isActive: () => boolean
+) => {
+  // Start following so a freshly opened, still-growing source pins to its tail
+  // even though it usually mounts scrolled to the top.
+  const following = ref(true)
+
+  const { arrivedState, directions, y } = useScroll(target, {
+    onScroll: () => {
+      if (directions.top) following.value = false // scrolled up → stop
+      else if (arrivedState.bottom) following.value = true // back at bottom → resume
+    }
+  })
+
+  // A wheel-up reaches us even when the target can't scroll (short content, or
+  // an auto-height embed where a parent scrolls) — the only "stop following"
+  // signal available there.
+  useEventListener(target, 'wheel', (e: WheelEvent) => { if (e.deltaY < 0) following.value = false }, { passive: true })
+
+  const pinToBottom = () => {
+    const el = toValue(target)
+    if (!el) return
+    // For an element, `y` sets its scrollTop; for the window we scroll to the
+    // document's full height (window has no scrollHeight of its own).
+    y.value = el instanceof Window
+      ? (document.scrollingElement ?? document.documentElement).scrollHeight
+      : el.scrollHeight
+  }
+
+  watch(growthSignal, () => { if (isActive() && following.value) pinToBottom() }, { flush: 'post' })
+
+  return { following }
+}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -15,6 +15,7 @@
     "build": "cd .. && npm run build"
   },
   "peerDependencies": {
+    "@vueuse/core": ">=10",
     "dayjs": "1",
     "ofetch": "1",
     "reconnecting-websocket": "4",
@@ -22,6 +23,9 @@
     "vue-router": "4 || 5"
   },
   "peerDependenciesMeta": {
+    "@vueuse/core": {
+      "optional": true
+    },
     "reconnecting-websocket": {
       "optional": true
     },


### PR DESCRIPTION
Add `useAutoScrollBottom` to `@data-fair/lib-vue`: a stick-to-bottom autoscroll composable for growing live regions (run logs, chat transcripts). It follows new content while the user is at the bottom, stops on any upward scroll or wheel-up, and resumes when scrolled back down. The `target` can be `window` or a getter to an inner `overflow: auto` element, so the same logic works whether the page scrolls as a whole or a nested container does.

**Why:** factor the stick-to-bottom autoscroll originally written in processings' run page into the shared lib so the agents chat (and any other live view) can reuse one implementation instead of each rolling its own.

**Regression risks:**
- Adds `@vueuse/core` (`>=10`) as an **optional** peer dependency — consumers that don't import this composable are unaffected, and npm won't error if it's absent. Both current consumers (agents, processings) already depend on `@vueuse/core ^13`.
- New file only; no existing exports or code paths changed. Imported per-file (`@data-fair/lib-vue/auto-scroll-bottom.js`), consistent with the other composables — no barrel to update.
