### PR TITLE
perf(node,express): cache signing keys and avoid redundant auth work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/debug": "^4.1.10",
         "@types/eslint": "^9.6.1",
         "@types/express": "^5.0.6",
+        "@types/memoizee": "^0.4.12",
         "@types/node": "^22.5.3",
         "@types/sanitize-html": "^2.16.0",
         "@types/semver": "^7.5.8",
@@ -1004,6 +1005,13 @@
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/memoizee": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
+      "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -2576,6 +2584,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/dargs": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -3150,6 +3171,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3447,6 +3520,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -3527,6 +3615,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3601,6 +3699,15 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5441,6 +5548,15 @@
         "lru-cache": "6.0.0"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5522,6 +5638,31 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/memoizee/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
@@ -5824,6 +5965,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -7502,6 +7649,19 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7619,6 +7779,12 @@
       "peerDependencies": {
         "typescript": ">=4.0.0"
       }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8387,6 +8553,10 @@
         "agentkeepalive": "^4.5.0",
         "axios": "^1.7.7",
         "cacheable-lookup": "^7.0.0",
+        "cookie": "^0.7.2",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
+        "memoizee": "^0.4.17",
         "semver": "^7.6.3"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@types/debug": "^4.1.10",
         "@types/eslint": "^9.6.1",
         "@types/express": "^5.0.6",
-        "@types/memoizee": "^0.4.12",
         "@types/node": "^22.5.3",
         "@types/sanitize-html": "^2.16.0",
         "@types/semver": "^7.5.8",
@@ -1005,13 +1004,6 @@
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/memoizee": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
-      "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -2584,19 +2576,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/d": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/dargs": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -3171,58 +3150,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.64",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "esniff": "^2.0.1",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "ext": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3520,21 +3447,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/esniff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -3615,16 +3527,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3699,15 +3601,6 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "license": "ISC",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5548,15 +5441,6 @@
         "lru-cache": "6.0.0"
       }
     },
-    "node_modules/lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5638,31 +5522,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/memoizee": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
-      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "es5-ext": "^0.10.64",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/memoizee/node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "license": "MIT"
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
@@ -5965,12 +5824,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC"
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -7649,19 +7502,6 @@
         "readable-stream": "3"
       }
     },
-    "node_modules/timers-ext": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
-      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7779,12 +7619,6 @@
       "peerDependencies": {
         "typescript": ">=4.0.0"
       }
-    },
-    "node_modules/type": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8556,7 +8390,6 @@
         "cookie": "^0.7.2",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",
-        "memoizee": "^0.4.17",
         "semver": "^7.6.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/debug": "^4.1.10",
     "@types/eslint": "^9.6.1",
     "@types/express": "^5.0.6",
-    "@types/memoizee": "^0.4.12",
     "@types/node": "^22.5.3",
     "@types/sanitize-html": "^2.16.0",
     "@types/semver": "^7.5.8",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/debug": "^4.1.10",
     "@types/eslint": "^9.6.1",
     "@types/express": "^5.0.6",
+    "@types/memoizee": "^0.4.12",
     "@types/node": "^22.5.3",
     "@types/sanitize-html": "^2.16.0",
     "@types/semver": "^7.5.8",

--- a/packages/express/req-perf.test.ts
+++ b/packages/express/req-perf.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test'
+import { strict as assert } from 'assert'
+import { EventEmitter } from 'node:events'
+import { register } from 'prom-client'
+import { reqPerfWrap, reqPerfRouteName, reqPerfStep } from './req-perf.js'
+
+const mockReq = (): any => ({ method: 'GET', url: '/test' })
+
+describe('reqPerf', () => {
+  it('should record finish and total steps when the response finishes', async () => {
+    const req = mockReq()
+    const res = new EventEmitter() as any
+    reqPerfWrap(req, res)
+    reqPerfRouteName(req, '/test-route')
+    res.emit('finish')
+
+    const metric = await register.getSingleMetric('df_req_step_seconds')?.get()
+    const values = metric?.values.filter((v: any) => v.labels.routeName === '/test-route' && v.metricName === 'df_req_step_seconds_count')
+    assert.ok(values?.find(v => v.labels.step === 'finish' && v.value === 1), 'finish step should be observed')
+    assert.ok(values?.find(v => v.labels.step === 'total' && v.value === 1), 'total step should be observed')
+  })
+
+  it('should record intermediate steps', async () => {
+    const req = mockReq()
+    const res = new EventEmitter() as any
+    reqPerfWrap(req, res)
+    reqPerfRouteName(req, '/test-route2')
+    reqPerfStep(req, 'step1')
+
+    const metric = await register.getSingleMetric('df_req_step_seconds')?.get()
+    const values = metric?.values.filter((v: any) => v.labels.routeName === '/test-route2' && v.metricName === 'df_req_step_seconds_count')
+    assert.ok(values?.find(v => v.labels.step === 'step1' && v.value === 1), 'step1 should be observed')
+  })
+})

--- a/packages/express/req-perf.ts
+++ b/packages/express/req-perf.ts
@@ -23,8 +23,8 @@ export const reqPerfWrap = (req: Request, res: Response) => {
   // @ts-ignore
   req[reqObserveKey] = { start, step: start }
   res.on('finish', () => {
-    exports.reqStep(req, 'finish')
-    exports.reqStep(req, 'total')
+    reqPerfStep(req, 'finish')
+    reqPerfStep(req, 'total')
   })
 }
 

--- a/packages/express/session.ts
+++ b/packages/express/session.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Account, SessionState, SessionStateAuthenticated, User } from '@data-fair/lib-common-types/session/index.js'
 import type { Request, Response, RequestHandler } from 'express'
 import cookie from 'cookie'
-import { validate, assertAdminMode, assertAuthenticated } from '@data-fair/lib-common-types/session/index.js'
+import { assertAdminMode, assertAuthenticated } from '@data-fair/lib-common-types/session/index.js'
 import { reqSitePathSafe } from '@data-fair/lib-express'
 import { SessionHandler } from '@data-fair/lib-node/session.js'
 
@@ -27,8 +27,10 @@ export class Session extends SessionHandler {
   async req (req: Request | IncomingMessage, res?: Response | ServerResponse): Promise<SessionState> {
     // @ts-ignore
     if (req[sessionKey]) return req[sessionKey]
+    // note: no schema validation of the session state, the token signature was already verified
+    // and a previous ajv validation proved useless (its result was ignored and it could never pass
+    // anyway because the schema does not accept the exp/iat claims present in the payload)
     const sessionState = await this.readState(req, res)
-    validate(sessionState)
     // @ts-ignore
     req[sessionKey] = sessionState
     return sessionState
@@ -58,7 +60,10 @@ export class Session extends SessionHandler {
   }
 
   async readState (req: Request | IncomingMessage, res?: Response | ServerResponse): Promise<SessionState> {
-    return this.readStateFromCookie(req.headers.cookie, this.onlyDecode?.(req), res && (() => this.unsetCookies(req, res)))
+    // reuse req.cookies if a cookie-parser middleware already populated it, to avoid re-parsing the Cookie header
+    // @ts-ignore - cookies is set by cookie-parser, absent on plain IncomingMessage
+    const cookies = req.cookies ?? req.headers.cookie
+    return this.readStateFromCookie(cookies, this.onlyDecode?.(req), res && (() => this.unsetCookies(req, res)))
   }
 
   middleware (options: { required?: boolean, adminOnly?: boolean } = {}): RequestHandler {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,7 +24,6 @@
     "cookie": "^0.7.2",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",
-    "memoizee": "^0.4.17",
     "semver": "^7.6.3"
   },
   "peerDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,18 +16,22 @@
   },
   "dependencies": {
     "@data-fair/lib-common-types": "^1.8.4",
-    "@data-fair/lib-validation": "^1.0.0",
     "@data-fair/lib-utils": "^1.1.0",
+    "@data-fair/lib-validation": "^1.0.0",
     "agentkeepalive": "^4.5.0",
     "axios": "^1.7.7",
     "cacheable-lookup": "^7.0.0",
+    "cookie": "^0.7.2",
+    "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.1.0",
+    "memoizee": "^0.4.17",
     "semver": "^7.6.3"
   },
   "peerDependencies": {
     "mongodb": "6",
     "prom-client": "15",
-    "ws": "8",
-    "tough-cookie": "5"
+    "tough-cookie": "5",
+    "ws": "8"
   },
   "peerDependenciesMeta": {
     "mongodb": {
@@ -47,7 +51,7 @@
   "devDependencies": {
     "mongodb": "^6.9.0",
     "prom-client": "^15.1.3",
-    "ws": "^8.18.0",
-    "tough-cookie": "^5.0.0"
+    "tough-cookie": "^5.0.0",
+    "ws": "^8.18.0"
   }
 }

--- a/packages/node/session.test.ts
+++ b/packages/node/session.test.ts
@@ -1,6 +1,29 @@
 import { describe, it } from 'node:test'
 import { strict as assert } from 'assert'
+import { generateKeyPairSync } from 'node:crypto'
+import jwt from 'jsonwebtoken'
 import { SessionHandler } from './session.js'
+
+const testUser = {
+  email: 'test@example.com',
+  id: 'user1',
+  name: 'Test User',
+  organizations: [
+    { id: 'org1', name: 'Test Org', role: 'admin' },
+    { id: 'org2', name: 'Other Org', role: 'user', department: 'dep1', departmentName: 'Department 1' }
+  ]
+}
+
+// a handler whose token verification is stubbed, counts the number of verifications
+const stubbedHandler = () => {
+  const handler = new SessionHandler()
+  const calls = { count: 0 }
+  handler.verifyToken = async () => {
+    calls.count++
+    return structuredClone(testUser)
+  }
+  return { handler, calls }
+}
 
 describe('SessionHandler.readStateFromCookie', () => {
   it('should return default session with no cookies', async () => {
@@ -42,5 +65,109 @@ describe('SessionHandler.readStateFromCookie', () => {
     const handler = new SessionHandler()
     const state = await handler.readStateFromCookie('id_token=header.payload')
     assert.equal(state.user, undefined)
+  })
+
+  it('should select the organization account from cookies', async () => {
+    const { handler } = stubbedHandler()
+    const state = await handler.readStateFromCookie('id_token=h.p; id_token_sign=s; id_token_org=org2; id_token_dep=dep1')
+    assert.equal(state.account?.type, 'organization')
+    assert.equal(state.account?.id, 'org2')
+    assert.equal(state.account?.department, 'dep1')
+    assert.equal(state.accountRole, 'user')
+  })
+
+  it('should build a user account when no org cookie', async () => {
+    const { handler } = stubbedHandler()
+    const state = await handler.readStateFromCookie('id_token=h.p; id_token_sign=s')
+    assert.equal(state.account?.type, 'user')
+    assert.equal(state.account?.id, 'user1')
+    assert.equal(state.accountRole, 'admin')
+  })
+
+  it('should accept an already-parsed cookies object without re-parsing', async () => {
+    const { handler, calls } = stubbedHandler()
+    const parsed = { id_token: 'h.p', id_token_sign: 's', id_token_org: 'org2', id_token_dep: 'dep1', i18n_lang: 'en', theme_dark: '1' }
+    const state = await handler.readStateFromCookie(parsed)
+    assert.equal(state.lang, 'en')
+    assert.equal(state.dark, true)
+    assert.equal(state.account?.type, 'organization')
+    assert.equal(state.account?.id, 'org2')
+    assert.equal(calls.count, 1)
+  })
+
+  it('should produce equivalent state from string and object cookie inputs', async () => {
+    const { handler } = stubbedHandler()
+    const fromString = await handler.readStateFromCookie('id_token=h.p; id_token_sign=s; i18n_lang=en')
+    const fromObject = await handler.readStateFromCookie({ id_token: 'h.p', id_token_sign: 's', i18n_lang: 'en' })
+    assert.deepEqual(fromString, fromObject)
+  })
+
+  it('should verify the token on every request', async () => {
+    const { handler, calls } = stubbedHandler()
+    const cookies = 'id_token=h.p; id_token_sign=s'
+    await handler.readStateFromCookie(cookies)
+    await handler.readStateFromCookie(cookies)
+    assert.equal(calls.count, 2)
+  })
+
+  it('should return a mutable state that callers can adjust', async () => {
+    const { handler } = stubbedHandler()
+    const state = await handler.readStateFromCookie('id_token=h.p; id_token_sign=s')
+    state.user!.name = 'mutated' // must not throw
+    state.user!.organizations[0].role = 'other'
+    assert.equal(state.user!.name, 'mutated')
+    assert.equal(state.user!.organizations[0].role, 'other')
+  })
+
+  it('should decode without verifying in onlyDecode mode', async () => {
+    const handler = new SessionHandler()
+    const token = jwt.sign(structuredClone(testUser), 'secret')
+    const [header, payload, sign] = token.split('.')
+    const state = await handler.readStateFromCookie(`id_token=${header}.${payload}; id_token_sign=${sign}`, true)
+    assert.equal(state.user?.id, 'user1')
+    assert.equal(state.account?.type, 'user')
+  })
+
+  it('should reject and clear the session when the token is invalid', async () => {
+    const handler = new SessionHandler()
+    handler.verifyToken = async () => { throw Object.assign(new Error('jwt expired'), { name: 'TokenExpiredError' }) }
+    let cleared = false
+    await assert.rejects(
+      handler.readStateFromCookie('id_token=h.p; id_token_sign=s', undefined, () => { cleared = true }),
+      (err: any) => err.status === 401
+    )
+    assert.equal(cleared, true)
+  })
+
+  it('should surface a 500 without clearing the session on a jwks error', async () => {
+    const handler = new SessionHandler()
+    handler.verifyToken = async () => { throw Object.assign(new Error('jwks down'), { name: 'JwksError' }) }
+    let cleared = false
+    await assert.rejects(
+      handler.readStateFromCookie('id_token=h.p; id_token_sign=s', undefined, () => { cleared = true }),
+      (err: any) => err.status === 500
+    )
+    assert.equal(cleared, false)
+  })
+})
+
+describe('SessionHandler.verifyToken', () => {
+  it('should verify a token and cache the signing key per kid', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const pem = publicKey.export({ format: 'pem', type: 'spki' }) as string
+    const handler = new SessionHandler()
+    let getSigningKeyCalls = 0
+    ;(handler as any)._jwksClient = {
+      getSigningKey: async () => {
+        getSigningKeyCalls++
+        return { getPublicKey: () => pem }
+      }
+    }
+    const token = jwt.sign({ id: 'user1' }, privateKey, { algorithm: 'RS256', keyid: 'kid1' })
+    const payload1 = await handler.verifyToken(token)
+    assert.equal(payload1.id, 'user1')
+    const payload2 = await handler.verifyToken(token)
+    assert.equal(payload2.id, 'user1')
+    assert.equal(getSigningKeyCalls, 1)
   })
 })

--- a/packages/node/session.ts
+++ b/packages/node/session.ts
@@ -3,7 +3,6 @@ import { createPublicKey, type KeyObject } from 'node:crypto'
 import jwt from 'jsonwebtoken'
 import JwksClient from 'jwks-rsa'
 import cookie from 'cookie'
-import memoize from 'memoizee'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 
 type TokenSessionState = Omit<SessionState, 'lang' | 'dark'>
@@ -24,10 +23,21 @@ export class SessionHandler {
   // jwks-rsa caches the JWK per kid but it exports a new PEM string at every access
   // and jsonwebtoken parses PEM strings again at every verification
   // caching the parsed KeyObject per kid skips both costs
-  private getSigningKeyObject = memoize(async (kid?: string): Promise<KeyObject> => {
-    const signingKey = await this.jwksClient.getSigningKey(kid)
-    return createPublicKey(signingKey.getPublicKey())
-  }, { promise: true, primitive: true, maxAge: 600000 })
+  // the cache holds the pending promise so concurrent calls dedupe, and drops it on failure
+  private _signingKeyObjects = new Map<string, Promise<KeyObject>>()
+  private getSigningKeyObject (kid?: string): Promise<KeyObject> {
+    const cacheKey = kid ?? ''
+    let promise = this._signingKeyObjects.get(cacheKey)
+    if (!promise) {
+      promise = (async () => {
+        const signingKey = await this.jwksClient.getSigningKey(kid)
+        return createPublicKey(signingKey.getPublicKey())
+      })()
+      promise.catch(() => this._signingKeyObjects.delete(cacheKey))
+      this._signingKeyObjects.set(cacheKey, promise)
+    }
+    return promise
+  }
 
   // used for the main session token, but can also be used to use the jwks to verify other types of tokens
   async verifyToken (token: string): Promise<any> {

--- a/packages/node/session.ts
+++ b/packages/node/session.ts
@@ -1,8 +1,12 @@
 import type { SessionState, User } from '@data-fair/lib-common-types/session/index.js'
+import { createPublicKey, type KeyObject } from 'node:crypto'
 import jwt from 'jsonwebtoken'
 import JwksClient from 'jwks-rsa'
 import cookie from 'cookie'
+import memoize from 'memoizee'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
+
+type TokenSessionState = Omit<SessionState, 'lang' | 'dark'>
 
 export class SessionHandler {
   private _jwksClient: JwksClient.JwksClient | undefined
@@ -17,30 +21,96 @@ export class SessionHandler {
     this._jwksClient = JwksClient({ jwksUri: directoryUrl + '/.well-known/jwks.json' })
   }
 
+  // jwks-rsa caches the JWK per kid but it exports a new PEM string at every access
+  // and jsonwebtoken parses PEM strings again at every verification
+  // caching the parsed KeyObject per kid skips both costs
+  private getSigningKeyObject = memoize(async (kid?: string): Promise<KeyObject> => {
+    const signingKey = await this.jwksClient.getSigningKey(kid)
+    return createPublicKey(signingKey.getPublicKey())
+  }, { promise: true, primitive: true, maxAge: 600000 })
+
   // used for the main session token, but can also be used to use the jwks to verify other types of tokens
   async verifyToken (token: string): Promise<any> {
     const decoded = jwt.decode(token, { complete: true })
     if (!decoded) throw new Error('failed to decode token')
-    const signingKey = await this.jwksClient.getSigningKey(decoded.header.kid)
-    return jwt.verify(token, signingKey.getPublicKey())
+    const signingKeyObject = await this.getSigningKeyObject(decoded.header.kid)
+    return jwt.verify(token, signingKeyObject)
   }
 
-  async readStateFromCookie (cookieStr: string | undefined, onlyDecode?: boolean, clearBrokenSession?: () => void): Promise<SessionState> {
-    const session: SessionState = { lang: this.defaultLang }
-    if (!cookieStr) return session
-    const cookies = cookie.parse(cookieStr)
-    session.dark = cookies.theme_dark === '1' || cookies.theme_dark === 'true'
-    if (cookies.i18n_lang) session.lang = cookies.i18n_lang
+  private buildTokenSessionState (user: User, organizationId: string, departmentId: string, switchedRole: string): TokenSessionState {
+    const state: TokenSessionState = {}
 
-    if (!cookies.id_token) return session
-    if (!cookies.id_token_sign && !onlyDecode) return session
-    const token = cookies.id_token + '.' + cookies.id_token_sign
+    // this is to prevent null values that are put by SD versions that do not strictly respect their schema
+    for (const org of user.organizations) {
+      if (!org.department) {
+        delete org.department
+        delete org.departmentName
+      }
+    }
+
+    state.user = user
+
+    if (organizationId) {
+      state.organization = user.organizations.find(o => {
+        if (o.id !== organizationId) return false
+        if (departmentId && departmentId !== o.department) return false
+        if (switchedRole && switchedRole !== o.role) return false
+        return true
+      })
+    }
+    if (state.organization) {
+      state.account = {
+        type: 'organization',
+        id: state.organization.id,
+        name: state.organization.name,
+        department: state.organization.department,
+        departmentName: state.organization.departmentName
+      }
+      state.accountRole = state.organization.role
+    } else {
+      state.account = {
+        type: 'user',
+        id: user.id,
+        name: user.name
+      }
+      state.accountRole = 'admin'
+      return state
+    }
+
+    if (state.user?.siteOwner) {
+      if (state.user.siteOwner.type === 'user' && state.user.siteOwner.id === state.user.id) {
+        state.siteRole = 'admin'
+      }
+      if (state.user.siteOwner.type === 'organization' && state.user.siteOwner.id === state.organization?.id) {
+        state.siteRole = state.organization.role
+      }
+    }
+    return state
+  }
+
+  // accepts either the raw Cookie header or an already-parsed cookies object
+  // (e.g. req.cookies when a cookie-parser middleware already ran upstream) to
+  // avoid re-parsing and allocating a second cookies object per request
+  async readStateFromCookie (rawCookies: string | Record<string, string | undefined> | undefined, onlyDecode?: boolean, clearBrokenSession?: () => void): Promise<SessionState> {
+    if (!rawCookies) return { lang: this.defaultLang }
+    const cookies = typeof rawCookies === 'string' ? cookie.parse(rawCookies) : rawCookies
+
+    const lang = cookies.i18n_lang || this.defaultLang
+    const dark = cookies.theme_dark === '1' || cookies.theme_dark === 'true'
+
+    if (!cookies.id_token) return { lang, dark }
+    if (!cookies.id_token_sign && !onlyDecode) return { lang, dark }
+    const token = cookies.id_token + '.' + (cookies.id_token_sign ?? '')
+    const organizationId = cookies.id_token_org ?? ''
+    const departmentId = cookies.id_token_dep ?? ''
+    const switchedRole = cookies.id_token_role ?? ''
+
     let user: User
     if (onlyDecode) {
       user = jwt.decode(token) as User
     } else {
       try {
-        user = await this.verifyToken(token)
+        user = await this.verifyToken(token) as User
       } catch (err: any) {
         console.warn(err)
         if (err.name === 'JwksError') {
@@ -53,56 +123,7 @@ export class SessionHandler {
         }
       }
     }
-    if (!user) return session
-
-    // this is to prevent null values that are put by SD versions that do not strictly respect their schema
-    for (const org of user.organizations) {
-      if (!org.department) {
-        delete org.department
-        delete org.departmentName
-      }
-    }
-
-    session.user = user
-
-    const organizationId = cookies.id_token_org
-    const departmentId = cookies.id_token_dep
-    const switchedRole = cookies.id_token_role
-    if (organizationId) {
-      session.organization = user.organizations.find(o => {
-        if (o.id !== organizationId) return false
-        if (departmentId && departmentId !== o.department) return false
-        if (switchedRole && switchedRole !== o.role) return false
-        return true
-      })
-    }
-    if (session.organization) {
-      session.account = {
-        type: 'organization',
-        id: session.organization.id,
-        name: session.organization.name,
-        department: session.organization.department,
-        departmentName: session.organization.departmentName
-      }
-      session.accountRole = session.organization.role
-    } else {
-      session.account = {
-        type: 'user',
-        id: user.id,
-        name: user.name
-      }
-      session.accountRole = 'admin'
-      return session
-    }
-
-    if (session.user?.siteOwner) {
-      if (session.user.siteOwner.type === 'user' && session.user.siteOwner.id === session.user.id) {
-        session.siteRole = 'admin'
-      }
-      if (session.user.siteOwner.type === 'organization' && session.user.siteOwner.id === session.organization?.id) {
-        session.siteRole = session.organization.role
-      }
-    }
-    return session
+    if (!user) return { lang, dark }
+    return Object.assign({ lang, dark } as SessionState, this.buildTokenSessionState(user, organizationId, departmentId, switchedRole))
   }
 }


### PR DESCRIPTION
Cache the parsed public signing key per `kid` and trim redundant per-request work in session handling.

**Why:** session auth ran avoidable work on every request — jwks-rsa re-exported a PEM and jsonwebtoken re-parsed it on each verify, the Cookie header was parsed twice when a cookie-parser already ran, and an ajv `validate()` whose result was discarded.

**What changed:**
- Cache the parsed `KeyObject` per `kid` in a `Map` (caches the pending promise to dedupe concurrent lookups, drops it on failure) so PEM export/parse is skipped on repeat verifications.
- `readStateFromCookie` accepts an already-parsed cookies object; `lib-express` passes `req.cookies` when present to avoid a second parse.
- Remove the discarded `validate(sessionState)` call (it never threw and could never pass given `exp`/`iat` claims).
- Refactor session-state assembly into `buildTokenSessionState`; declare previously-undeclared runtime deps (`cookie`, `jsonwebtoken`, `jwks-rsa`) in `lib-node`.
- Fix `reqPerfWrap`'s finish handler, which called a non-existent `exports.reqStep` and so never recorded the `finish`/`total` step metrics.

**Regression risks:**
- The signing-key `Map` has no expiry: new `kid`s miss and fetch fresh (normal rotation unaffected); only a same-`kid` key swap would serve stale, which JWKS rotation doesn't do.
- Dropped `validate()` is a confirmed no-op — no behavior change.
- `req.cookies` reuse assumes cookie-parser decoding matches `cookie.parse` (true by default); double-check any app with custom/signed-cookie config.
- `df_req_step_seconds` now actually records `finish`/`total` steps that were silently missing before.
