### PR TITLE
feat(vue): add onConfirmLeave callback to useLeaveGuard

### DIFF
--- a/packages/vue/leave-guard.ts
+++ b/packages/vue/leave-guard.ts
@@ -11,7 +11,8 @@ const messages: Record<string, string> = {
 
 type LeaveGuardOptions = {
   locale?: MaybeRefOrGetter<string>,
-  message?: string
+  message?: string,
+  onConfirmLeave?: () => void
 }
 
 export const useLeaveGuard = (isDirty: MaybeRefOrGetter<boolean>, options?: LeaveGuardOptions) => {
@@ -20,7 +21,9 @@ export const useLeaveGuard = (isDirty: MaybeRefOrGetter<boolean>, options?: Leav
   // vue router guard
   onBeforeRouteLeave(() => {
     if (!toValue(isDirty)) return
-    return window.confirm(getMessage())
+    const leave = window.confirm(getMessage())
+    if (leave) options?.onConfirmLeave?.()
+    return leave
   })
 
   // browser guard


### PR DESCRIPTION
Add an optional `onConfirmLeave` callback to `useLeaveGuard`. It fires when the user confirms leaving during an in-app navigation (the `onBeforeRouteLeave` guard), after `window.confirm` returns true and before the navigation proceeds — letting the caller react, e.g. abort an in-flight request.

**Why:** a consumer (data-fair) guards against navigating away while a file upload is running. When the user confirms they want to leave, the in-flight upload request must be aborted so the dataset creation/update is actually stopped. The guard previously only returned the confirm result to the router, with no hook to run such side effects, forcing the consumer to reimplement the whole composable locally.

**Regression risks:**
- `LeaveGuardOptions` gains an optional `onConfirmLeave?: () => void` — backward compatible (defaulted/absent), existing callers are unaffected.
- The callback only runs on the in-app `onBeforeRouteLeave` path when the user confirms; the `beforeunload` (tab close / reload) path is unchanged, since browsers don't let scripts run reliable side effects there.
