### PR TITLE
feat(vue): allow extra params in ws subscribe messages

### DIFF
--- a/packages/vue/ws.ts
+++ b/packages/vue/ws.ts
@@ -12,16 +12,18 @@ const getWS = (path: string) => {
   const ws = new ReconnectingWebSocket(url)
 
   const subscriptions = reactive({} as Record<string, ((message: any) => void)[]>)
+  const subscribeParams: Record<string, Record<string, any>> = {}
   const opened = ref(false)
 
   ws.addEventListener('open', () => {
     opened.value = true
     for (const channel of Object.keys(subscriptions)) {
       if (subscriptions[channel].length) {
-        ws.send(JSON.stringify({ type: 'subscribe', channel }))
+        ws.send(JSON.stringify({ type: 'subscribe', channel, ...subscribeParams[channel] }))
       } else {
         ws.send(JSON.stringify({ type: 'unsubscribe', channel }))
         delete subscriptions[channel]
+        delete subscribeParams[channel]
       }
     }
   })
@@ -39,10 +41,11 @@ const getWS = (path: string) => {
     }
   }
 
-  function subscribe <T> (channel: string, listener: (message: T) => void) {
+  function subscribe <T> (channel: string, listener: (message: T) => void, params?: Record<string, any>) {
     if (!subscriptions[channel]) {
       subscriptions[channel] = []
-      if (opened.value) ws.send(JSON.stringify({ type: 'subscribe', channel }))
+      if (params) subscribeParams[channel] = params
+      if (opened.value) ws.send(JSON.stringify({ type: 'subscribe', channel, ...params }))
     }
     subscriptions[channel].push(listener)
 
@@ -57,6 +60,7 @@ const getWS = (path: string) => {
       if (subscriptions[channel].length === 0 && opened.value) {
         ws.send(JSON.stringify({ type: 'unsubscribe', channel }))
         delete subscriptions[channel]
+        delete subscribeParams[channel]
       }
     }
   }


### PR DESCRIPTION
`useWS().subscribe` gains an optional third argument `params` — an opaque bag of fields merged into the subscribe message (`{ type: 'subscribe', channel, ...params }`). The params are remembered per channel and replayed when the socket reconnects and re-subscribes, then dropped on unsubscribe. lib-vue stays agnostic about what they mean.

**Why:** a consumer (data-fair) needs an unauthenticated client — a visualization opened through a protected-link application key — to subscribe to a dataset's realtime channels (journal, task-progress). A browser WebSocket handshake carries no `Referer`, so the application key cannot reach the server the way it does over HTTP; passing it in the subscribe message is the way in. This gives the consumer a generic transport (`subscribe(channel, cb, { applicationKey })`) without lib-vue knowing about application keys.

**Regression risks:**
- `subscribe` gains an optional third parameter — backward compatible, existing two-arg calls are unaffected.
- Only the subscribe message shape changes, and only when `params` is provided; the reconnect-replay and unsubscribe paths now also carry then clear these params. No exports renamed or removed.
