### PR TITLE
feat(node): set a default Data-Fair User-Agent on axios requests

### DIFF
--- a/packages/node/axios.ts
+++ b/packages/node/axios.ts
@@ -29,7 +29,13 @@ export function axiosBuilder (opts: CreateAxiosDefaults = {}, beforeInterceptors
   const ax = axios.create({
     httpAgent,
     httpsAgent,
-    ...opts
+    ...opts,
+    headers: {
+      // identifies requests coming from the data-fair stack, with a contact URL as
+      // recommended/required by policies like https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
+      'User-Agent': 'Data-Fair (https://github.com/data-fair)',
+      ...opts.headers
+    }
   })
 
   if (beforeInterceptors) beforeInterceptors(ax)


### PR DESCRIPTION
Set a default `User-Agent: Data-Fair (https://github.com/data-fair)` header on every axios instance built by lib-node's `axiosBuilder`.

**Why:** outbound requests from the stack previously sent no `User-Agent`, making them unidentifiable in target servers' logs and non-compliant with policies that require one (e.g. the Wikimedia Foundation User-Agent policy). The contact URL points to the public repo so administrators have a way to reach us.

The header is an instance default and stays overridable via `opts.headers` or per-request config.

**Heads-up:** this is a stack-wide default — all axios requests built through lib-node now carry a `User-Agent` where they sent none before. Raw WebSocket handshakes in `ws-client.ts` bypass axios and are not covered.
