### PR TITLE
fix(utils): do not parse style attributes in shared sanitize-html options

### DIFF
--- a/packages/utils/sanitize-html.ts
+++ b/packages/utils/sanitize-html.ts
@@ -6,5 +6,9 @@ export const getSanitizeOpts = (defaults: SanitizeDefaults): SanitizeOptions => 
     ...defaults.allowedAttributes,
     '*': ['class'],
     img: ['title', 'alt', 'src', 'srcset', 'height', 'width', 'sizes', 'loading']
-  }
+  },
+  // style attributes are not allowed above, parsing them would uselessly run postcss,
+  // which is also not browser compatible (node builtins externalized by vite).
+  // note: a consumer extending these opts with allowedStyles must switch this back to true
+  parseStyleAttributes: false
 })


### PR DESCRIPTION
`getSanitizeOpts` does not allow `style` attributes, yet sanitize-html's default `parseStyleAttributes: true` made every sanitization parse them with postcss before throwing them away. Since the policy "no style attributes" is decided here, its corollary "do not parse them" now lives here too.

**Why:** postcss is not browser compatible — its node builtins imports (`path`, `url`, `source-map-js`) are externalized by vite and produced warnings on every sanitization in dev (seen in data-fair/portals; data-fair has the same consumers). Skipping the parse also removes useless work server-side.

**Heads-up:** a consumer extending these opts with `allowedStyles` will get an explicit error from sanitize-html ("allowedStyles option cannot be used together with parseStyleAttributes: false") and must consciously switch `parseStyleAttributes` back to `true`. No current consumer uses `allowedStyles` (checked portals, data-fair, events, catalogs, processings, simple-directory).
