### PR TITLE
fix(node): unref the http agents metrics interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "quality": "eslint . && npm test",
     "prepublishOnly": "npm run quality && npm run build",
     "pre-test": "cd packages/types-builder/test && node --experimental-strip-types ../build.ts . --vjsf-dir=vjsf --no-cache",
-    "test": "npm run pre-test && node --experimental-strip-types --test --test-force-exit **/*.test.ts",
-    "test-only": "npm run pre-test && node --experimental-strip-types --test --test-force-exit --test-only"
+    "test": "npm run pre-test && node --experimental-strip-types --test **/*.test.ts",
+    "test-only": "npm run pre-test && node --experimental-strip-types --test --test-only"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/node/http-agents.test.ts
+++ b/packages/node/http-agents.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test'
+import { strict as assert } from 'assert'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { fileURLToPath } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+
+describe('http agents', () => {
+  it('should not keep a process alive just by being imported', async () => {
+    const modulePath = fileURLToPath(new URL('./http-agents.ts', import.meta.url))
+    try {
+      await execFileAsync(
+        process.execPath,
+        ['--experimental-strip-types', '--input-type=module', '--eval', `import ${JSON.stringify(modulePath)}`],
+        { timeout: 10000 }
+      )
+    } catch (err) {
+      assert.fail(`importing http-agents did not exit on its own (${(err as Error).message}), a module level timer is probably missing an unref()`)
+    }
+  })
+})

--- a/packages/node/http-agents.ts
+++ b/packages/node/http-agents.ts
@@ -44,6 +44,9 @@ const requestCounter = new Counter({
   labelNames: ['protocol']
 })
 
+// unref'd so that importing this module never keeps a process alive on its own:
+// a server is kept running by its own handles and still gets the metrics, while
+// CLIs, tests and build tools can exit normally
 setInterval(() => {
   for (const _protocol of ['http', 'https']) {
     const protocol = _protocol as 'http' | 'https'
@@ -59,4 +62,4 @@ setInterval(() => {
     requestCounter.remove({ protocol })
     requestCounter.inc({ protocol }, agentStatus.requestCount)
   }
-}, 60000)
+}, 60000).unref()


### PR DESCRIPTION
The module level `setInterval` collecting prom-client metrics in `lib-node/http-agents` was never unref'd, so merely importing the module — directly, or transitively through `axios.js` and `lib-express/serve-spa` — kept the event loop alive forever. Any process whose only remaining handle was that timer could never exit on its own: CLIs, build tools and test runners hung indefinitely once they were done.

**Why:** it silently forced workarounds in two separate places. This repo has been carrying `--test-force-exit` since `701cd5c`, added in the very commit that introduced `packages/express/session.test.ts` — the only test that was hanging. Downstream, data-fair portals had a `close` hook calling `process.exit(0)` in its nuxt config, commented as a nitropack/esbuild problem, which it never was.

- unref the interval — servers are kept running by their own handles and still collect metrics on the same 60s cadence, so their behaviour is unchanged
- add a regression test asserting a child process importing the module exits on its own
- drop `--test-force-exit`; the suite now runs 71/71 without it

**Heads-up:** dropping `--test-force-exit` means a future leaked handle in any test surfaces as a CI hang rather than a silent pass. That is the intent, but it changes the failure mode — expect a timeout, not an error message.

`packages/express/ws-server.ts` has the same shape and is **not** addressed here: its ping `setInterval` is neither unref'd nor cleared by `stop()`. It is not module level, so importing stays harmless, but a process that called `start()` still cannot exit on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
